### PR TITLE
update Dockerfile to build with raspberry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGET=cpu
 # ===============================================================================
 # Base stage (Common dependencies for CPU and NVIDIA GPU builds)
 # ===============================================================================
-FROM osrf/ros:humble-desktop-full-jammy AS base
+FROM ros:humble-ros-base-jammy AS base
 ARG USE_CI
 
 RUN apt-get update


### PR DESCRIPTION
I suggest to change base docker to be able to build on a raspberry pi.
Tested on raspberry pi5 with 16GB of RAM and using Ubuntu 24.04 OS
